### PR TITLE
feat: add get closed pools feature

### DIFF
--- a/src/app/Components/heroSection.tsx
+++ b/src/app/Components/heroSection.tsx
@@ -26,7 +26,7 @@ export default function HeroSection() {
           </p>
           <div className="mb-16">
             <Link
-              href="#explore"
+              href="dashboard/pool-market"
               className="bg-[#37B7C3] hover:bg-cyan-500 text-slate-900 font-medium px-8 py-3 rounded-full transition-colors inline-block"
             >
               Explore Pool Market

--- a/src/app/Components/navBar.tsx
+++ b/src/app/Components/navBar.tsx
@@ -56,7 +56,7 @@ export default function Navbar() {
 
         <div className="hidden md:block">
           <Link
-            href="#explore"
+            href="dashboard/pool-market"
             className="bg-[#37B7C3] hover:bg-cyan-500 text-slate-900 font-medium px-4 py-2 rounded-md transition-colors"
           >
             Explore Pools
@@ -95,7 +95,7 @@ export default function Navbar() {
             COMMUNITY
           </Link>
           <Link
-            href="#explore"
+            href="dashboard/pool-market"
             className="bg-cyan-400 hover:bg-cyan-500 text-slate-900 font-medium px-4 py-2 rounded-md transition-colors w-full text-center mt-4"
             onClick={() => setIsMenuOpen(false)}
           >

--- a/src/app/hooks/useGetClosedPools.ts
+++ b/src/app/hooks/useGetClosedPools.ts
@@ -1,0 +1,40 @@
+import { useReadContract } from "@starknet-react/core";
+import { PREDIFI_ABI } from "../abi/predifi_abi";
+import { PREDIFI_CONTRACT_ADDRESS } from "@/static";
+
+interface UseGetClosedPoolsOptions {
+  enabled?: boolean;
+  watch?: boolean;
+  refetchInterval?:
+    | number
+    | false
+    | ((query: any) => number | false | undefined);
+}
+
+const useGetClosedPools = ({
+  enabled = true,
+  watch = false,
+  refetchInterval,
+}: UseGetClosedPoolsOptions = {}) => {
+  const { data, error, isLoading, status } = useReadContract({
+    abi: PREDIFI_ABI,
+    functionName: "get_closed_pools",
+    address: PREDIFI_CONTRACT_ADDRESS,
+    args: [],
+    enabled,
+    watch,
+    refetchInterval,
+  });
+
+  // TODO: parse the data to make sure we are returning it in the correct format
+  const closedPools = data || [];
+
+  return {
+    data: closedPools,
+    error,
+    isLoading,
+    status,
+  };
+};
+
+export default useGetClosedPools;

--- a/src/constants/functionNames.ts
+++ b/src/constants/functionNames.ts
@@ -1,1 +1,2 @@
 export const GET_POOL = "get_pool"
+export const GET_CLOSED_POOLS = "get_closed_pools"


### PR DESCRIPTION
## Description

This pull request includes updates to navigation links and introduces a new hook for fetching closed pools. The navigation changes improve the user experience by linking directly to the pool market dashboard, while the new hook enhances the codebase by providing reusable functionality for fetching data from the `get_closed_pools` contract function.

### Navigation Updates:
* Updated the `href` attribute in `HeroSection` and `Navbar` components to link directly to `dashboard/pool-market` instead of `#explore` for better navigation. (`src/app/Components/heroSection.tsx`: [[1]](diffhunk://#diff-8783a225319f1a97e9f348ea4bdc2145e6f4fc822ed566f8b969d7c07f108c6fL29-R29) `src/app/Components/navBar.tsx`: [[2]](diffhunk://#diff-631fd84df34a82875b08d6e6c021d9ab5a6fe05a9245e8d10ea3b0dfff616864L59-R59) [[3]](diffhunk://#diff-631fd84df34a82875b08d6e6c021d9ab5a6fe05a9245e8d10ea3b0dfff616864L98-R98)

### New Hook for Fetching Closed Pools:
* Added a new custom hook `useGetClosedPools` in `src/app/hooks/useGetClosedPools.ts` to fetch data from the `get_closed_pools` function of the `PREDIFI` contract. This hook includes options for enabling/disabling, watching, and setting a refetch interval.
* Added a new constant `GET_CLOSED_POOLS` in `src/constants/functionNames.ts` to represent the `get_closed_pools` function name.

Closes  #45 