### PR TITLE
feat: implemented get pool creator

### DIFF
--- a/src/app/hooks/useGetPoolCreator.ts
+++ b/src/app/hooks/useGetPoolCreator.ts
@@ -1,0 +1,39 @@
+import { useReadContract } from "@starknet-react/core";
+import { PREDIFI_ABI } from "../abi/predifi_abi";
+import { PREDIFI_CONTRACT_ADDRESS } from "@/static";
+
+interface useGetPoolCreatorInterface {
+  enabled?: boolean;
+  watch?: boolean;
+  poolId?: string;
+  refetchInterval?:
+    | number
+    | false
+    | ((query: any) => number | false | undefined);
+}
+
+function useGetPoolCreator({
+  enabled = true,
+  watch = false,
+  poolId,
+  refetchInterval,
+}: useGetPoolCreatorInterface) {
+  const { data, error, isLoading, status } = useReadContract({
+    abi: PREDIFI_ABI,
+    functionName: "get_pool_creator",
+    address: PREDIFI_CONTRACT_ADDRESS,
+    args: [poolId],
+    enabled,
+    watch,
+    refetchInterval,
+  });
+
+  return {
+    data,
+    error,
+    isLoading,
+    status,
+  };
+}
+
+export default useGetPoolCreator;


### PR DESCRIPTION
Resolve #66 
This PR adds a custom hook useGetPoolCreator to fetch the creator of a pool from the PreDifi contract using useReadContract from @starknet-react/core.

Hook Params:

- poolId: Pool identifier

- enabled: Toggle the query (default: true)

- watch: Enable live updates (default: false)

- refetchInterval: Set polling interval or disable it

Returns:

- data, error, isLoading, status